### PR TITLE
Make 'online' message retained again

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -53,7 +53,7 @@ def on_mqtt_connect(client, userdata, flags, rc):
         topic=opentherm.topic_namespace,
         payload="online",
         qos=settings['mqtt']['qos'],
-        retain=settings['mqtt']['retain'])
+        retain=True)
 
 def on_mqtt_message(client, userdata, msg):
     # Handle incoming messages


### PR DESCRIPTION
When a consumer starts after py-otgw-mqtt, it previously received the last-will 'offline' message from the top level topic, even while py-otgw-mqtt is still running.

Behavior observed and change tested on mosquitto 1.4.10-3+deb9u2 from Debian

Changing the 'offline' message to match the setting (and deleting the retained will) works as well, but I assume it was left hardcoded at True intentionally.
